### PR TITLE
Latest PhyML stats files fail parsing

### DIFF
--- a/taxtastic/refpkg.py
+++ b/taxtastic/refpkg.py
@@ -499,7 +499,7 @@ class Refpkg(object):
                           line.startswith('You are using RAxML')):
                         stats_type = 'RAxML'
                         break
-                    elif 'PhyML v3.0' in line:
+                    elif 'PhyML' in line:
                         stats_type = 'PhyML'
                         break
                 else:

--- a/taxtastic/subcommands/create.py
+++ b/taxtastic/subcommands/create.py
@@ -67,6 +67,9 @@ def build_parser(parser):
                         action="store", dest="tree_stats",
                         help=('File containing tree statistics (for example '
                               'RAxML_info.whatever")'), metavar='FILE')
+    parser.add_argument("--stats-type", choices=('PhyML', 'FastTree', 'RAxML'),
+                        help="""stats file type [default: attempt to guess from
+                        file contents]""")
     parser.add_argument("-S", "--aln-sto",
                         action="store", dest="aln_sto",
                         help='Multiple alignment in Stockholm format', metavar='FILE')
@@ -117,7 +120,7 @@ def action(args):
     if args.package_version:
         r.update_metadata('package_version', args.package_version)
     if args.tree_stats:
-        r.update_phylo_model(None, args.tree_stats)
+        r.update_phylo_model(args.stats_type, args.tree_stats)
 
     for file_name in ['aln_fasta', 'aln_sto', 'mask',
                       'profile', 'seq_info', 'taxonomy', 'tree', 'tree_stats',

--- a/taxtastic/utils.py
+++ b/taxtastic/utils.py
@@ -181,7 +181,7 @@ def parse_fasttree(fobj):
         'Price-CAT': {},
     }
     for line in fobj:
-        if not line: continue
+        if not line.strip(): continue
         splut = line.split()
         if splut[0] == 'FastTree':
             data['program'] = line.strip()


### PR DESCRIPTION
The header line in PhyML stats file has changed from `PhyML v3.0` to a date, i.e. `PhyML 20120412`
