### PR TITLE
Doesn't make an "empirical_frequencies" key when doing AA for phyml

### DIFF
--- a/taxtastic/utils.py
+++ b/taxtastic/utils.py
@@ -232,10 +232,6 @@ def parse_phyml(fobj):
         if rates:
             result['subs_rates'] = rates
 
-        # PhyML doesn't record whether empirical base frequencies were used, or
-        # ML estimates were made.
-        # Setting to empirical for now.
-        result['empirical_frequencies'] = True
     elif 'amino acids' in s:
         result['datatype'] = 'AA'
         try_set_fields(result,
@@ -243,6 +239,11 @@ def parse_phyml(fobj):
                        s)
     else:
         raise ValueError('Could not determine if alignment is AA or DNA')
+
+    # PhyML doesn't record whether empirical base frequencies were used, or
+    # ML estimates were made.
+    # Setting to empirical for now.
+    result['empirical_frequencies'] = True
 
     return result
 

--- a/testfiles/phyml_aa_stats.txt.json
+++ b/testfiles/phyml_aa_stats.txt.json
@@ -6,5 +6,6 @@
   "gamma": {
     "alpha": 0.626, 
     "n_cats": 4
-  }
+  },
+  "empirical_frequencies": true
 }


### PR DESCRIPTION
```
mus taxtastic/testfiles ‹master› » cat phyml_aa_stats.txt.json
{
  "datatype": "AA", 
  "subs_model": "LG", 
  "program": "PhyML v3.0_export", 
  "ras_model": "gamma", 
  "gamma": {
    "alpha": 0.626, 
    "n_cats": 4
  }
}
```

This makes pplacer choke. 
