### PR TITLE
adding schema prefix to queries for postgres compatibility

### DIFF
--- a/taxtastic/ncbi.py
+++ b/taxtastic/ncbi.py
@@ -324,7 +324,7 @@ def load_table(engine, table, rows, colnames=None, limit=None):
     conn.commit()
 
 
-def set_names_is_classified(engine, unclassified_regex=UNCLASSIFIED_REGEX, schema=None):
+def set_names_is_classified(engine, unclassified_regex=UNCLASSIFIED_REGEX, schema=''):
     conn = engine.raw_connection()
     cur = conn.cursor()
     placeholder = {'pysqlite': '?', 'psycopg2': '%s'}[engine.driver]
@@ -386,7 +386,7 @@ def set_names_is_classified(engine, unclassified_regex=UNCLASSIFIED_REGEX, schem
     conn.commit()
 
 
-def set_nodes_is_valid(engine, unclassified_regex=UNCLASSIFIED_REGEX, schema=None):
+def set_nodes_is_valid(engine, unclassified_regex=UNCLASSIFIED_REGEX, schema=''):
     conn = engine.raw_connection()
     cur = conn.cursor()
     placeholder = {'pysqlite': '?', 'psycopg2': '%s'}[engine.driver]
@@ -418,7 +418,7 @@ def set_nodes_is_valid(engine, unclassified_regex=UNCLASSIFIED_REGEX, schema=Non
     conn.commit()
 
 
-def db_load(engine, archive, ranks=RANKS, schema=None):
+def db_load(engine, archive, ranks=RANKS, schema=''):
     """Load data from zip archive into database identified by con.
 
     """

--- a/taxtastic/ncbi.py
+++ b/taxtastic/ncbi.py
@@ -335,12 +335,10 @@ def set_names_is_classified(engine, unclassified_regex=UNCLASSIFIED_REGEX, schem
     JOIN {nodes} USING(tax_id)
     WHERE is_primary
     AND rank = 'species'
-    """.format(names=schema+'names',
-               nodes=schema+'nodes')
-
+    """.format(names=schema + 'names',
+               nodes=schema + 'nodes')
 
     cur.execute(cmd)
-
     log.info('retrieving species names')
     primary_species_names = cur.fetchall()
     log.info('found {} species names'.format(len(primary_species_names)))
@@ -355,7 +353,7 @@ def set_names_is_classified(engine, unclassified_regex=UNCLASSIFIED_REGEX, schem
 
     # insert tax_ids into a temporary table
     tempname = random_name(12)
-    temptab = schema+tempname
+    temptab = schema + tempname
 
     cmd = 'CREATE TEMPORARY TABLE "{tab}" (tax_id text)'.format(tab=temptab)
     log.info(cmd)
@@ -379,7 +377,7 @@ def set_names_is_classified(engine, unclassified_regex=UNCLASSIFIED_REGEX, schem
     is_classified = {{ placeholder }}
     WHERE is_primary
     AND tax_id IN (SELECT tax_id FROM "{{ tab }}")
-    """).render(tab=temptab, placeholder=placeholder, names=schema+'names')
+    """).render(tab=temptab, placeholder=placeholder, names=schema + 'names')
 
     log.info(cmd)
     cur.execute(cmd, (True,))
@@ -407,14 +405,14 @@ def set_nodes_is_valid(engine, unclassified_regex=UNCLASSIFIED_REGEX, schema='')
     )
     UPDATE {nodes} SET is_valid = {placeholder}
     WHERE tax_id in (SELECT tax_id from descendants)
-    """.format(names=schema+'names',
-               nodes=schema+'nodes',
+    """.format(names=schema + 'names',
+               nodes=schema + 'nodes',
                placeholder=placeholder)
 
     log.info(cmd)
     log.info('marking invalid nodes')
 
-    cur.execute(cmd,(False,))
+    cur.execute(cmd, (False, ))
     conn.commit()
 
 
@@ -427,35 +425,35 @@ def db_load(engine, archive, ranks=RANKS, schema=''):
 
     # source
     load_table(
-        engine, schema+'source',
+        engine, schema + 'source',
         rows=[('ncbi', DATA_URL)],
         colnames=['name', 'description'],
     )
 
     cur = conn.cursor()
-    cur.execute("select id from {source} where name = 'ncbi'".format(source=schema+'source'))
+    cur.execute("select id from {source} where name = 'ncbi'".format(source=schema + 'source'))
     source_id = cur.fetchone()[0]
 
     # ranks
     log.info('loading ranks')
     ranks_rows = [('rank', 'height')]
     ranks_rows += [(rank, i) for i, rank in enumerate(RANKS)]
-    load_table(engine, schema+'ranks', rows=iter(ranks_rows))
+    load_table(engine, schema + 'ranks', rows=iter(ranks_rows))
 
     # nodes
     logging.info('loading nodes')
     nodes_rows = read_nodes(read_archive(archive, 'nodes.dmp'), source_id=source_id)
-    load_table(engine, schema+'nodes', rows=nodes_rows)
+    load_table(engine, schema + 'nodes', rows=nodes_rows)
 
     # names
     logging.info('loading names')
     names_rows = read_names(read_archive(archive, 'names.dmp'), source_id=source_id)
-    load_table(engine, schema+'names', rows=names_rows)
+    load_table(engine, schema + 'names', rows=names_rows)
 
     # merged
     logging.info('loading merged')
     merged_rows = read_merged(read_archive(archive, 'merged.dmp'))
-    load_table(engine, schema+'merged', rows=merged_rows)
+    load_table(engine, schema + 'merged', rows=merged_rows)
 
     conn.commit()
 

--- a/taxtastic/subcommands/extract_nodes.py
+++ b/taxtastic/subcommands/extract_nodes.py
@@ -74,7 +74,6 @@ def action(args):
         # parents.
         tax_ids = map(itemgetter('tax_id'), nodes)
         lineages = tax._get_lineage_table(tax_ids)
-        print(lineages)
         ordering = {}
         for i, lineage in enumerate(lineages):
             tax_id = lineage[1]

--- a/taxtastic/subcommands/extract_nodes.py
+++ b/taxtastic/subcommands/extract_nodes.py
@@ -21,7 +21,7 @@ import logging
 import sqlalchemy
 from itertools import groupby
 from operator import itemgetter
-from collections import OrderedDict
+# from collections import OrderedDict
 
 import yaml
 from fastalite import Opener
@@ -53,7 +53,6 @@ def build_parser(parser):
 def action(args):
     engine = sqlalchemy.create_engine(args.url, echo=args.verbosity > 2)
     tax = Taxonomy(engine, schema=args.schema)
-
 
     with engine.connect() as con:
         # TODO: need to order nodes so that parents are always created first

--- a/taxtastic/subcommands/extract_nodes.py
+++ b/taxtastic/subcommands/extract_nodes.py
@@ -54,15 +54,16 @@ def action(args):
     engine = sqlalchemy.create_engine(args.url, echo=args.verbosity > 2)
     tax = Taxonomy(engine, schema=args.schema)
 
+
     with engine.connect() as con:
         # TODO: need to order nodes so that parents are always created first
 
         cmd = """
         select nodes.*, source.name as source_name
-        from nodes
-        join source on nodes.source_id = source.id
+        from {nodes}
+        join {source} on nodes.source_id = source.id
         where source.name = {x}
-        """.format(x=tax.placeholder)
+        """.format(x=tax.placeholder, nodes=tax.nodes, source=tax.source)
 
         result = con.execute(cmd, (args.source_name,))
         keys = result.keys()
@@ -73,7 +74,7 @@ def action(args):
         # parents.
         tax_ids = map(itemgetter('tax_id'), nodes)
         lineages = tax._get_lineage_table(tax_ids)
-
+        print(lineages)
         ordering = {}
         for i, lineage in enumerate(lineages):
             tax_id = lineage[1]
@@ -84,10 +85,10 @@ def action(args):
 
         cmd = """
         select names.*, source.name as source_name
-        from names
-        join source on names.source_id = source.id
+        from {names}
+        join {source} on names.source_id = source.id
         where source.name = {x}
-        """.format(x=tax.placeholder)
+        """.format(x=tax.placeholder, names=tax.names, source=tax.source)
 
         result = con.execute(cmd, (args.source_name,))
         keys = result.keys()

--- a/taxtastic/subcommands/new_database.py
+++ b/taxtastic/subcommands/new_database.py
@@ -77,11 +77,14 @@ def action(args):
             url=args.taxdump_url)
 
     engine = sqlalchemy.create_engine(args.url, echo=args.verbosity > 2)
-    taxtastic.ncbi.db_connect(engine, schema=args.schema, clobber=args.clobber)
 
-    taxtastic.ncbi.db_load(engine, archive=zfile, schema=args.schema)
-    taxtastic.ncbi.set_names_is_classified(engine, schema=args.schema)
-    taxtastic.ncbi.set_nodes_is_valid(engine, schema=args.schema)
+    # taxtastic.ncbi.db_connect(engine, schema=args.schema, clobber=args.clobber)
+
+    schema_prefix = args.schema + '.' if args.schema else ''
+
+    # taxtastic.ncbi.db_load(engine, archive=zfile, schema=schema_prefix)
+    taxtastic.ncbi.set_names_is_classified(engine, schema=schema_prefix)
+    taxtastic.ncbi.set_nodes_is_valid(engine, schema=schema_prefix)
 
     # print_sql(args.out, engine.name, base.metadata)
 

--- a/taxtastic/subcommands/new_database.py
+++ b/taxtastic/subcommands/new_database.py
@@ -78,11 +78,11 @@ def action(args):
 
     engine = sqlalchemy.create_engine(args.url, echo=args.verbosity > 2)
 
-    # taxtastic.ncbi.db_connect(engine, schema=args.schema, clobber=args.clobber)
+    taxtastic.ncbi.db_connect(engine, schema=args.schema, clobber=args.clobber)
 
     schema_prefix = args.schema + '.' if args.schema else ''
 
-    # taxtastic.ncbi.db_load(engine, archive=zfile, schema=schema_prefix)
+    taxtastic.ncbi.db_load(engine, archive=zfile, schema=schema_prefix)
     taxtastic.ncbi.set_names_is_classified(engine, schema=schema_prefix)
     taxtastic.ncbi.set_nodes_is_valid(engine, schema=schema_prefix)
 

--- a/taxtastic/subcommands/new_database.py
+++ b/taxtastic/subcommands/new_database.py
@@ -79,9 +79,9 @@ def action(args):
     engine = sqlalchemy.create_engine(args.url, echo=args.verbosity > 2)
     taxtastic.ncbi.db_connect(engine, schema=args.schema, clobber=args.clobber)
 
-    taxtastic.ncbi.db_load(engine, archive=zfile)
-    taxtastic.ncbi.set_names_is_classified(engine)
-    taxtastic.ncbi.set_nodes_is_valid(engine)
+    taxtastic.ncbi.db_load(engine, archive=zfile, schema=args.schema)
+    taxtastic.ncbi.set_names_is_classified(engine, schema=args.schema)
+    taxtastic.ncbi.set_nodes_is_valid(engine, schema=args.schema)
 
     # print_sql(args.out, engine.name, base.metadata)
 

--- a/taxtastic/subcommands/taxtable.py
+++ b/taxtastic/subcommands/taxtable.py
@@ -151,7 +151,7 @@ def action(args):
         sys.exit('Error: no tax_ids were specified')
 
     engine = sqlalchemy.create_engine(args.url, echo=args.verbosity > 3)
-    tax = Taxonomy(engine)
+    tax = Taxonomy(engine, schema=args.schema)
 
     rows = tax._get_lineage_table(tax_ids)
     log.info('grouping lineages')

--- a/taxtastic/subcommands/update_taxids.py
+++ b/taxtastic/subcommands/update_taxids.py
@@ -88,15 +88,15 @@ def action(args):
         unknowns.writeheader()
 
     engine = sqlalchemy.create_engine(args.url, echo=args.verbosity > 3)
-    tax = Taxonomy(engine, taxtastic.ncbi.RANKS)
+    tax = Taxonomy(engine, taxtastic.ncbi.RANKS, schema=args.schema)
 
     with tax.engine.connect() as con:
         log.info('reading table merged')
-        result = con.execute('select old_tax_id, new_tax_id from merged')
+        result = con.execute('select old_tax_id, new_tax_id from {merged}'.format(merged=tax.merged))
         mergedict = dict(result.fetchall())
 
-        log.info('reading tax_ids from table nodes')
-        result = con.execute('select tax_id from nodes')
+        log.info('reading tax_ids from table {nodes}'.format(nodes=tax.nodes))
+        result = con.execute('select tax_id from {nodes}'.format(nodes=tax.nodes))
         all_tax_ids = {x[0] for x in result.fetchall()}
 
     log.info('reading input file')

--- a/taxtastic/taxonomy.py
+++ b/taxtastic/taxonomy.py
@@ -77,6 +77,7 @@ class Taxonomy(object):
         self.source = self.meta.tables[schema_prefix + 'source']
         self.merged = self.meta.tables[schema_prefix + 'merged']
         ranks_table = self.meta.tables[schema_prefix + 'ranks']
+        self.ranks_table = ranks_table
         ranks = select([ranks_table.c.rank, ranks_table.c.height]).execute().fetchall()
         ranks = sorted(ranks, key=lambda x: int(x[1]))  # sort by height
         self.ranks = [r[0] for r in ranks]  # just the ordered ranks
@@ -220,7 +221,7 @@ class Taxonomy(object):
         )
         SELECT a.rank, a.tax_id FROM a
         JOIN {ranks} using(rank)
-        """.format(self.placeholder, nodes=self.nodes, ranks=self.ranks)
+        """.format(self.placeholder, nodes=self.nodes, ranks=self.ranks_table)
 
         # with some versions of sqlite3, an error is raised when no
         # rows are returned; with others, an empty list is returned.

--- a/taxtastic/taxonomy.py
+++ b/taxtastic/taxonomy.py
@@ -82,6 +82,7 @@ class Taxonomy(object):
         self.ranks = [r[0] for r in ranks]  # just the ordered ranks
 
         self.NO_RANK = NO_RANK
+        self.schema = schema
 
         # TODO: can probably remove this check at some point;
         # historically the root node had tax_id == parent_id ==
@@ -246,7 +247,9 @@ class Taxonomy(object):
         try:
             with self.engine.connect() as con:
                 # insert tax_ids into a temporary table
-                temptab = random_name(12)
+
+                temptab = self.schema + '.' + random_name(12) if self.schema else random_name(12)
+
                 cmd = 'CREATE TEMPORARY TABLE "{tab}" (old_tax_id text)'.format(
                     tab=temptab)
                 con.execute(cmd)

--- a/taxtastic/taxonomy.py
+++ b/taxtastic/taxonomy.py
@@ -218,8 +218,8 @@ class Taxonomy(object):
           FROM a JOIN {nodes} p ON a.parent_id = p.tax_id
         )
         SELECT a.rank, a.tax_id FROM a
-        JOIN ranks using(rank)
-        """.format(self.placeholder, nodes=self.nodes)
+        JOIN {ranks} using(rank)
+        """.format(self.placeholder, nodes=self.nodes, ranks=self.ranks)
 
         # with some versions of sqlite3, an error is raised when no
         # rows are returned; with others, an empty list is returned.


### PR DESCRIPTION
I've worked my way through some of the subcommands adding the schema prefix to queries where needed, but there may be some spots I've missed. Usually just added `schema=args.schema` where a Taxonomy object created, then modified any raw sql queries to include the schema if any using string substitution.