### PR TITLE
Fixed column order and added check for self-reference to root 

### DIFF
--- a/taxtastic/subcommands/taxtable.py
+++ b/taxtastic/subcommands/taxtable.py
@@ -170,7 +170,7 @@ def action(args):
     # Now do a sanity check to be sure every row has a parent_id. If the parent node is empty (ie root) make it self-referential 
     # There are fancier ways to do this but a for loop will suffice. I'll use indices to replace in-situ and preserve memory
     for i in xrange(len(output)):
-        if output[i]['parent_id'] == None or output[i]['parent_id'] == "":
+        if output[i]['parent_id'] is None or output[i]['parent_id'] == "":
             output[i]['parent_id'] = output[i]['tax_id']
 
     log.info('writing taxtable')

--- a/taxtastic/subcommands/taxtable.py
+++ b/taxtastic/subcommands/taxtable.py
@@ -163,11 +163,15 @@ def action(args):
         all_ranks |= set(ranks)
 
     sorted_ranks = sorted(all_ranks, key=order_ranks(tax.ranks[::-1]))
-    fieldnames = ['tax_id', 'parent_id', 'tax_name', 'rank'] + sorted_ranks
-
+    fieldnames = ['tax_id', 'parent_id', 'rank', 'tax_name'] + sorted_ranks
     output = taxtable.values()
     log.info('sorting lineages')
     output = sorted(output, key=getitems(*sorted_ranks))
+    # Now do a sanity check to be sure every row has a parent_id. If the parent node is empty (ie root) make it self-referential 
+    # There are fancier ways to do this but a for loop will suffice. I'll use indices to replace in-situ and preserve memory
+    for i in xrange(len(output)):
+        if output[i]['parent_id'] == None or output[i]['parent_id'] == "":
+            output[i]['parent_id'] = output[i]['tax_id']
 
     log.info('writing taxtable')
     writer = csv.DictWriter(

--- a/taxtastic/subcommands/taxtable.py
+++ b/taxtastic/subcommands/taxtable.py
@@ -167,7 +167,7 @@ def action(args):
     output = taxtable.values()
     log.info('sorting lineages')
     output = sorted(output, key=getitems(*sorted_ranks))
-    # Now do a sanity check to be sure every row has a parent_id. If the parent node is empty (ie root) make it self-referential 
+    # Now do a sanity check to be sure every row has a parent_id. If the parent node is empty (ie root) make it self-referential
     # There are fancier ways to do this but a for loop will suffice. I'll use indices to replace in-situ and preserve memory
     for i in xrange(len(output)):
         if output[i]['parent_id'] is None or output[i]['parent_id'] == "":


### PR DESCRIPTION
Very minor but important changes to the taxtable subcommand to make the output compatible with guppy.