### PR TITLE
Entered LG-model (Fasttree) in lines 116 and 150

### DIFF
--- a/taxtastic/utils.py
+++ b/taxtastic/utils.py
@@ -113,7 +113,7 @@ JTT_MODEL = ('ML Model: Jones-Taylor-Thorton, CAT '
              'approximation with 20 rate categories')
 WAG_MODEL = ('ML Model: Whelan-And-Goldman, CAT '
              'approximation with 20 rate categories')
-
+LG_MODEL = 'ML Model: Le-Gascuel 2008, CAT approximation with 20 rate categories'
 
 def parse_fasttree(fobj):
     data = {
@@ -145,6 +145,10 @@ def parse_fasttree(fobj):
             data['empirical_frequencies'] = False
         elif line.strip() == WAG_MODEL:
             data['subs_model'] = 'WAG'
+            data['datatype'] = 'AA'
+            data['empirical_frequencies'] = False
+        elif line.strip() == LG_MODEL:
+            data['subs_model'] = 'LG'
             data['datatype'] = 'AA'
             data['empirical_frequencies'] = False
 


### PR DESCRIPTION
I needed to make a reference package with FastTree using the LG substitution model (supported by PPLACER), and got the following error msg:

taxtastic.utils.InvalidLogError: GTR model, but no substitution rates found!

I entered the LG-model as an option in lines 116 and 150 and now I can create a reference package on my system.

_________________
Here are the first few lines of a fasttree LG log:

Command: FastTree -lg -log LOVref11.aln.lg.tree.log LOVref11.aln.fasta
FastTree Version 2.1.9 No SSE3
Alignment: LOVref11.aln.fasta
Amino acid distances: BLOSUM45 Joins: balanced Support: SH-like 1000
Search: Normal +NNI +SPR (2 rounds range 10) +ML-NNI opt-each=1
TopHits: 1.00*sqrtN close=default refresh=0.80
ML Model: Le-Gascuel 2008, CAT approximation with 20 rate categories
Read 2729 sequences, 243 positions