### PR TITLE
UNCLASSIFIED_REGEX update

### DIFF
--- a/taxtastic/ncbi.py
+++ b/taxtastic/ncbi.py
@@ -123,7 +123,7 @@ UNCLASSIFIED_REGEX_COMPONENTS = [r'-like\b',
                                  r'^\W+\s+[a-zA-Z]*\d',  # Digit in second word
                                  r'\d\d',
                                  r'atypical',
-                                 r'^cf\.',
+                                 r'\bcf\.',
                                  r'acidophile',
                                  r'\bactinobacterium\b',
                                  r'aerobic',

--- a/taxtastic/subcommands/named.py
+++ b/taxtastic/subcommands/named.py
@@ -61,7 +61,7 @@ def action(args):
         fieldnames = seq_info.fieldnames
         seq_info = list(seq_info)
         tax_ids = (i['tax_id'] for i in seq_info)
-        named = set(tax.is_valid(tax_ids, no_rank=not args.ranked))
+        named = set(tax.is_valid(tax_ids, exclude_no_rank=args.ranked))
         out = csv.DictWriter(args.outfile, fieldnames=fieldnames)
         out.writeheader()
         out.writerows(i for i in seq_info if i['tax_id'] in named)
@@ -71,7 +71,7 @@ def action(args):
         else:
             tax_ids = (i.strip() for i in args.tax_id_file)
             tax_ids = [i for i in tax_ids if i]
-        named = set(tax.is_valid(tax_ids, no_rank=not args.ranked))
+        named = set(tax.is_valid(tax_ids, exclude_no_rank=args.ranked))
         tax_ids = (i for i in tax_ids if i in named)
         for i in tax_ids:
             args.outfile.write(i + '\n')

--- a/taxtastic/taxonomy.py
+++ b/taxtastic/taxonomy.py
@@ -853,12 +853,12 @@ class Taxonomy(object):
         with self.engine.connect() as con:
             return [row[0] for row in con.execute(cmd).fetchall()]
 
-    def is_valid(self, tax_ids=None, no_rank=True):
+    def is_valid(self, tax_ids=None, exclude_no_rank=True):
         """Return all classified tax_ids"""
         nodes = self.nodes
         s = select(nodes.c.tax_id).where(nodes.c.is_valid)
         if tax_ids:
             s = s.where(nodes.c.tax_id.in_(set(tax_ids)))
-        if no_rank:
-            s = s.where(nodes.c.rank == 'no_rank')
+        if exclude_no_rank:
+            s = s.where(nodes.c.rank != 'no_rank')
         return [r[0] for r in self.fetchall(s)]

--- a/taxtastic/taxonomy.py
+++ b/taxtastic/taxonomy.py
@@ -859,6 +859,6 @@ class Taxonomy(object):
         s = select(nodes.c.tax_id).where(nodes.c.is_valid)
         if tax_ids:
             s = s.where(nodes.c.tax_id.in_(set(tax_ids)))
-        if not no_rank:
+        if no_rank:
             s = s.where(nodes.c.rank == 'no_rank')
         return [r[0] for r in self.fetchall(s)]

--- a/tests/test_ncbi.py
+++ b/tests/test_ncbi.py
@@ -73,6 +73,74 @@ class TestUnclassifiedRegex(TestBase):
     Test the heuristic used to determine if a taxonomic name is meaningful.
     """
 
+    unclassified_regex_examples = [
+        (r'-like\b', 'WA-like'),
+        (r'\bactinomycete\b', 'actinomycete A4'),
+        (r'\bcrenarchaeote\b', 'crenarchaeote OlA-6'),
+        (r'\bculture\b', 'mixed culture'),
+        (r'\bchimeric\b', 'chimeric sequence SJA-7'),
+        (r'\bcyanobiont\b', 'Nostocaceae cyanobiont AE1'),
+        (r'degrading', '2,4-D degrading bacterium M1'),
+        (r'\beuryarchaeote\b', 'euryarchaeote D4.75-4'),
+        (r'disease', 'Fiji disease virus'),
+        (r'\b[cC]lone', 'soil clone WD1'),
+        (r'\bmethanogen(ic)?\b', 'methanogen 5c'),
+        (r'\bplanktonic\b', 'planktonic crenarchaeote'),
+        (r'\bplanctomycete\b', 'planctomycete A-2'),
+        (r'\bsymbiote\b', 'Ornithodoros moubata symbiote B'),
+        (r'\btransconjugant\b', '2,4-D degrading transconjugant WD2'),
+        (r'^(?!root$)[a-z]', 'liara'),
+        # No matching primary scientific name was found in ncbi_taxonomy.db
+        # for r'^\W+\s+[a-zA-Z]*\d'.
+        (r'\d\d', 'GB10C'),
+        (r'atypical', 'Limbodessus atypicalis'),
+        (r'\bcf\.', 'Doto cf. divae'),
+        (r'acidophile', 'acidophile enrichment culture'),
+        (r'\bactinobacterium\b', 'actinobacterium D'),
+        (r'aerobic', 'aerobic bacillus'),
+        (r'.+\b[Al]g(um|a)\b', 'Prosthecochloris sp. L21-Aga-LIT'),
+        (r'\b[Bb]acteri(um|al)\b', 'bacterium'),
+        (r'.+\b[Bb]acteria\b', 'cf. Bacteria SAR-1'),
+        (r'Barophile', 'Barophile WHB 46'),
+        (r'cyanobacterium', 'cyanobacterium G1'),
+        (r'Chloroplast', 'Chloroplast expression vector pCEV1'),
+        (r'Cloning', 'Cloning vector AC'),
+        (r'\bclone\b', 'soil clone WD1'),
+        (r'cluster', 'Cyclustera'),
+        (r'^diazotroph', 'diazotroph DU1'),
+        (r'\bcoccus\b', 'Dactylopius coccus'),
+        (r'archaeon', 'archaeon'),
+        (r'-containing', 'HSV-tk-containing vector pGTK3'),
+        (r'epibiont', 'epibiont metagenome'),
+        (r'environmental samples', 'environmental samples <bats>'),
+        (r'eubacterium', 'Desulfoeubacterium'),
+        (r'halophilic', 'halophilic archaeon'),
+        (r'hydrothermal\b', 'hydrothermal vent metagenome'),
+        (r'isolate', 'Biserrula isolate'),
+        (r'\bmarine\b', 'marine bacterium'),
+        (r'methanotroph', 'methanotroph B8'),
+        (r'microorganism', 'uncultured microorganism'),
+        (r'mollicute', "'Candidatus Bacilliplasma' mollicute"),
+        (r'pathogen', 'fungal pathogen UWFP-388'),
+        (r'[Pp]hytoplasma', 'Phytoplasma sp.'),
+        (r'proteobacterium', 'proteobacterium 1'),
+        (r'putative', 'uncultured putative methanotroph'),
+        (r'\bsp\.', 'Aix sp.'),
+        (r'species', 'Eucara species group'),
+        (r'spirochete', 'wall-less spirochete'),
+        (r'str\.', 'archaeal str. vp21'),
+        (r'strain', 'slope strain DI4'),
+        (r'symbiont', 'ant endosymbionts'),
+        (r'\b[Tt]axon\b', 'Bisgaard Taxon 2'),
+        (r'unicellular', 'Gesasha unicellularis'),
+        (r'uncultured', 'uncultured Ulva'),
+        (r'unclassified', 'unclassified Aa'),
+        (r'unidentified', 'unidentified'),
+        (r'unknown', 'HIV-1 unknown group'),
+        (r'vector\b', 'YTT vector A'),
+        (r'vent\b', 'Ripavent virus'),
+    ]
+
     def setUp(self):
         self.pieces = taxtastic.ncbi.UNCLASSIFIED_REGEX_COMPONENTS
         self.regexes = [re.compile(piece) for piece in self.pieces]
@@ -86,6 +154,21 @@ class TestUnclassifiedRegex(TestBase):
                 if m:
                     self.fail('"{0}" matches "{1}"'.format(
                         strain_name, regex.pattern))
+
+    def test_cf_prefix_matches(self):
+        self.assertRegex(
+            'cf. Pedicellasteridae sp. CLM-2010-1',
+            taxtastic.ncbi.UNCLASSIFIED_REGEX)
+
+    def test_cf_middle_matches(self):
+        self.assertRegex(
+            'Plasmodium cf. ovale',
+            taxtastic.ncbi.UNCLASSIFIED_REGEX)
+
+    def test_scientific_name_examples_match_components(self):
+        for pattern, tax_name in self.unclassified_regex_examples:
+            with self.subTest(pattern=pattern, tax_name=tax_name):
+                self.assertRegex(tax_name, re.compile(pattern))
 
 # def generate_test_unclassified_regex():
     #"""

--- a/tests/test_subcommands.py
+++ b/tests/test_subcommands.py
@@ -290,6 +290,31 @@ class TestTaxtable(TestBase):
         self.assertIsNone(main(args))
 
 
+class TestNamed(TestBase):
+
+    def setUp(self):
+        self.outdir = self.mkoutdir()
+        self.outfile = os.path.join(self.outdir, 'named.txt')
+
+    def output_taxids(self):
+        with open(self.outfile) as handle:
+            return [line.strip() for line in handle]
+
+    def test_ranked_excludes_no_rank(self):
+        args = [
+            'named',
+            '--ranked',
+            '--tax-ids',
+            '1287',
+            '1280',
+            '-o',
+            self.outfile,
+            config.ncbi_master_db,
+        ]
+        self.assertIsNone(main(args))
+        self.assertEqual(self.output_taxids(), ['1280'])
+
+
 class TestAddToTaxtable(TestBase):
     maxDiff = None
 

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -401,6 +401,14 @@ class TestTaxonomyTree(TestTaxonomyBase):
             self.tax.nary_subtree('1239'),
             ['1280', '1281', '45670', '138846'])
 
+    def test_is_valid_excludes_no_rank_by_default(self):
+        self.assertEqual(self.tax.is_valid(['1287']), [])
+        self.assertEqual(self.tax.is_valid(['1280']), ['1280'])
+
+    def test_is_valid_includes_no_rank_when_requested(self):
+        self.assertEqual(
+            self.tax.is_valid(['1287'], exclude_no_rank=False), ['1287'])
+
 
 class TestGetLineageTable(TestTaxonomyBase):
 
@@ -422,5 +430,3 @@ class TestGetLineageTable(TestTaxonomyBase):
 
         self.assertEqual(species['1280'].tax_name, 'Staphylococcus aureus')
         self.assertEqual(species['1379'].tax_name, 'Gemella haemolysans')
-
-


### PR DESCRIPTION
* Updated cf. line to include tax_names like "Doto cf. divae" and "cf. Pedicellasteridae sp. CLM-2010-1"
* Added unittests for each line in UNCLASSIFIED_REGEX except '^\\W+\\s+[a-zA-Z]*\\d' which does not match any ncbi scientific names